### PR TITLE
multi-pmu bugfixes

### DIFF
--- a/core/src/ieee_c37_118/common.rs
+++ b/core/src/ieee_c37_118/common.rs
@@ -337,7 +337,7 @@ pub struct ChannelInfo {
 /// * `leapbyte`: Time quality and leap second flags.
 /// * `fracsec`: Fractional second timestamp.
 /// * `version`: Derived IEEE C37.118 version (not serialized).
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct PrefixFrame {
     pub sync: u16, // SYNC field: frame type (bits 6-4), version (bits 3-0)
     pub framesize: u16,
@@ -445,7 +445,7 @@ impl PrefixFrame {
 /// * `time_quality`: Time quality code (3-bit in 2011/2024, 2-bit in 2005).
 /// * `unlock_time`: Unlock time code (2011/2024 only).
 /// * `trigger_reason`: 4-bit trigger reason code.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct StatField {
     pub raw: u16,            // Raw STAT value
     pub data_error: u8,      // 2-bit field (all versions)

--- a/core/src/ieee_c37_118/config.rs
+++ b/core/src/ieee_c37_118/config.rs
@@ -316,7 +316,11 @@ impl ConfigurationFrame {
             });
         }
 
-        validate_checksum(bytes).unwrap();
+        if validate_checksum(bytes).is_err() {
+            return Err(ParseError::InvalidChecksum {
+                message: format!("ConfigurationFrame: Checksum validation failed",),
+            });
+        }
 
         let mut offset = 14;
         let time_base = u32::from_be_bytes(bytes[offset..offset + 4].try_into().unwrap());

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -69,7 +69,8 @@ pub fn config_to_accumulators(
     let mut phasor_accumulators: Vec<PhasorAccumulatorConfig> = vec![];
 
     // Process each PMU configuration
-    let mut current_offset = 14 + 2; // Prefix + STAT
+
+    let mut current_offset = 14; // Prefix + STAT
 
     match output_phasor_type {
         Some(value) => println!("Converting phasor data to: {}", value),
@@ -89,7 +90,9 @@ pub fn config_to_accumulators(
     for pmu_config in pmu_configs {
         let station_name = String::from_utf8_lossy(&pmu_config.stn).trim().to_string();
 
-        // Process phasors
+        // TODO: Process STAT field.
+        current_offset += 2; // skipping stat field.
+
         if pmu_config.phnmr > 0 {
             let column_names = pmu_config.get_column_names();
             let phasor_column_names = column_names.iter().take(pmu_config.phnmr as usize);
@@ -176,6 +179,7 @@ pub fn config_to_accumulators(
                 station_name, pmu_config.idcode
             ),
         });
+
         current_offset += freq_size;
 
         // Process ROCOF (dfreq)
@@ -186,6 +190,7 @@ pub fn config_to_accumulators(
             scale_factor: 1,
             name: format!("{}_{}_DFREQ (ROCOF)", station_name, pmu_config.idcode),
         });
+
         current_offset += freq_size;
 
         // Process analog values


### PR DESCRIPTION
The STAT field is associated with each PMU instead of the overall PDC, which caused the byte alignment to be offset by -2 for each PMU phasor/anolog/digital start value. In turn this caused the parsed data to be nonsensical.

I debugged this issue by incorporating improving the random data frame generation in random.rs to use values, close to the IEEE standard examples, but with added noise.  I've also included additional test for parsing random multi-PMU data frames.

The changes in random.rs impact the mock-pdc stream when using --num-pmus > 1.